### PR TITLE
hide SafariViewController when auth0 returns error in callback from r…

### DIFF
--- a/01-Login/src/App.js
+++ b/01-Login/src/App.js
@@ -120,6 +120,11 @@ App.prototype.login = function(e) {
   client.authorize(options, function(err, authResult) {
     if (err) {
       console.log(err);
+      var isIOS = window.cordova.platformId === 'ios';
+      if (isIOS) {
+        SafariViewController.hide();
+      } 
+      alert(err);
       return (e.target.disabled = false);
     }
     localStorage.setItem('access_token', authResult.accessToken);


### PR DESCRIPTION

# Pull Request Report

Fix for iOS when login/signup is stuck when error is thrown from rules/actions

hide SafariViewController when auth0 returns error in callback from rules/actions to pass control back to the app instead of being in a frozen state in the browser.

### Description

Explicitly dismissing the safari view controller when the platform is iOS to return the callback to the app.

### Type of change

- [X] Bug fix (fix to an issue)
- [ ] New feature (changes to functionality)
- [ ] Big change (fix or feature that would cause existing functionality to work as expected)

### Testing

tested on iOS simulator and android 

**Test Configuration**

* Framework version:
* Language version:
* Browser version:

### Additional info

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings and errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
